### PR TITLE
[GB-83] Add Compromised password API check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,11 @@ HTTP_SERVER_PORT=3000
 GIN_MODE=release
 FIREBASE_CONFIG_FILE=/path/to/credential.json
 MYSQL_CONNECTION_STRING=root:P@ssw0rd@tcp(127.0.0.1:3306)/garnbarn?charset=utf8mb4&parseTime=True&loc=Local
+
 REDIS_CONNECTION_STRING=localhost:6379
 REDIS_PASSWORD=P@ssw0rd
 RATE_LIMIT_STRING=5-S
 REDIS_DB=0
+
+# Hibp API Credential
+HIBP_API_KEY=

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	REDIS_PASSWORD          string `envconfig:"REDIS_PASSWORD"`
 	RATE_LIMIT_STRING       string `envconfig:"RATE_LIMIT_STRING" default:"5-S"`
 	REDIS_DB                int    `envconfig:"REDIS_DB" default:"0"`
+	HIBP_API_KEY            string `envconfig:"HIBP_API_KEY"`
 }
 
 func Load() Config {

--- a/handler/account.go
+++ b/handler/account.go
@@ -16,9 +16,10 @@ type AccountHandler struct {
 	appConfig      config.Config
 }
 
-func NewAccountHandler(accountService service.AccountService) AccountHandler {
+func NewAccountHandler(accountService service.AccountService, appConfig config.Config) AccountHandler {
 	return AccountHandler{
 		accountService: accountService,
+		appConfig:      appConfig,
 	}
 }
 
@@ -52,7 +53,12 @@ func (a *AccountHandler) CheckForComprimizedPassword(c *gin.Context) {
 
 	if a.appConfig.HIBP_API_KEY == "" {
 		// For Internal testing purpose.
-		c.JSON(http.StatusOK, gin.H{"message": "ok"})
+		c.JSON(http.StatusOK, gin.H{"message": "Skipped check, (Internal)"})
+		return
+	}
+
+	if len(request.HashedPassword) != 40 {
+		c.JSON(http.StatusBadRequest, gin.H{"message": "Bad Request Body."})
 		return
 	}
 

--- a/handler/account.go
+++ b/handler/account.go
@@ -3,6 +3,8 @@ package handler
 import (
 	"net/http"
 
+	"github.com/GarnBarn/garnbarn-backend-go/config"
+	"github.com/GarnBarn/garnbarn-backend-go/model"
 	"github.com/GarnBarn/garnbarn-backend-go/service"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
@@ -11,6 +13,7 @@ import (
 
 type AccountHandler struct {
 	accountService service.AccountService
+	appConfig      config.Config
 }
 
 func NewAccountHandler(accountService service.AccountService) AccountHandler {
@@ -37,4 +40,31 @@ func (a *AccountHandler) GetAccount(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, account)
+}
+
+func (a *AccountHandler) CheckForComprimizedPassword(c *gin.Context) {
+	var request model.CheckCompromizedPasswordRequest
+	err := c.ShouldBind(&request)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"message": "Bad Request Body."})
+		return
+	}
+
+	if a.appConfig.HIBP_API_KEY == "" {
+		// For Internal testing purpose.
+		c.JSON(http.StatusOK, gin.H{"message": "ok"})
+		return
+	}
+
+	isCompromised, err := a.accountService.CheckForCompromisedPassword(request.HashedPassword)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"message": err})
+		return
+	}
+
+	if isCompromised {
+		c.JSON(http.StatusFound, gin.H{"message": "Your password has been compromised"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"message": "No passwd compromisation has been founded."})
 }

--- a/handler/account.go
+++ b/handler/account.go
@@ -43,7 +43,7 @@ func (a *AccountHandler) GetAccount(c *gin.Context) {
 }
 
 func (a *AccountHandler) CheckForComprimizedPassword(c *gin.Context) {
-	var request model.CheckCompromizedPasswordRequest
+	var request model.CheckCompromisedPasswordRequest
 	err := c.ShouldBind(&request)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"message": "Bad Request Body."})

--- a/main.go
+++ b/main.go
@@ -90,7 +90,7 @@ func main() {
 	// Init the handler
 	tagHandler := handler.NewTagHandler(*validate, tagService)
 	assignmentHandler := handler.NewAssignmentHandler(*validate, assignmentService, tagService)
-	accountHandler := handler.NewAccountHandler(accountService)
+	accountHandler := handler.NewAccountHandler(accountService, appConfig)
 
 	httpServer.Use(cors.New(cors.Config{
 		AllowOrigins:     []string{"*"},

--- a/main.go
+++ b/main.go
@@ -132,7 +132,7 @@ func main() {
 	// Account
 	accountRouter := router.Group("/account")
 	accountRouter.GET("/", authMiddleware, accountHandler.GetAccount)
-	accountRouter.POST("/compromized", accountHandler.CheckForComprimizedPassword)
+	accountRouter.POST("/compromised", accountHandler.CheckForComprimizedPassword)
 
 	logrus.Info("Listening and serving HTTP on :", appConfig.HTTP_SERVER_PORT)
 	httpServer.Run(fmt.Sprint(":", appConfig.HTTP_SERVER_PORT))

--- a/model/account.go
+++ b/model/account.go
@@ -30,6 +30,6 @@ type AccountPlatform struct {
 	Line string `json:"line"`
 }
 
-type CheckCompromizedPasswordRequest struct {
+type CheckCompromisedPasswordRequest struct {
 	HashedPassword string `json:"hashedPassword"`
 }

--- a/model/account.go
+++ b/model/account.go
@@ -29,3 +29,7 @@ type AccountPublic struct {
 type AccountPlatform struct {
 	Line string `json:"line"`
 }
+
+type CheckCompromizedPasswordRequest struct {
+	HashedPassword string `json:"hashedPassword"`
+}

--- a/service/account.go
+++ b/service/account.go
@@ -11,6 +11,7 @@ import (
 
 type AccountService interface {
 	GetUserByUid(uid string) (account model.AccountPublic, err error)
+	CheckForCompromisedPassword(hashedPassword string) (isCompromized bool, err error)
 }
 
 type accountService struct {
@@ -47,4 +48,15 @@ func (a *accountService) GetUserByUid(uid string) (account model.AccountPublic, 
 	}
 
 	return accountPrivate.ToAccountPublic(user.DisplayName, user.PhotoURL), nil
+}
+
+func (a *accountService) CheckForCompromisedPassword(hashedPassword string) (isCompromized bool, err error) {
+
+	// TODO: Make request to ihbp.
+
+	// TODO: Validate the response.
+
+	// TODO: Return the result.
+
+	return false, nil
 }

--- a/service/account.go
+++ b/service/account.go
@@ -11,7 +11,7 @@ import (
 
 type AccountService interface {
 	GetUserByUid(uid string) (account model.AccountPublic, err error)
-	CheckForCompromisedPassword(hashedPassword string) (isCompromized bool, err error)
+	CheckForCompromisedPassword(hashedPassword string) (isCompromised bool, err error)
 }
 
 type accountService struct {
@@ -50,7 +50,7 @@ func (a *accountService) GetUserByUid(uid string) (account model.AccountPublic, 
 	return accountPrivate.ToAccountPublic(user.DisplayName, user.PhotoURL), nil
 }
 
-func (a *accountService) CheckForCompromisedPassword(hashedPassword string) (isCompromized bool, err error) {
+func (a *accountService) CheckForCompromisedPassword(hashedPassword string) (isCompromised bool, err error) {
 
 	// TODO: Make request to ihbp.
 


### PR DESCRIPTION
## API Spec
POST `/api/v1/account/compromised/`

Body:
```
{
   hashedPassword: "1234"
}
```
Note: HashedPassword must be in form of SHA1 hash only!


Response:
302 --> Password has founded to be compromised.
200 --> Password is safe to be used.